### PR TITLE
#102492 команда проверки что все нужные топики созданы

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "orchestra/testbench": "^6.15",
         "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
-        "vimeo/psalm": "^4.4"
+        "vimeo/psalm": "^4.4",
+        "kwn/php-rdkafka-stubs": "^2.2"
     },
     "autoload": {
         "psr-4": {

--- a/config/kafka.php
+++ b/config/kafka.php
@@ -4,37 +4,38 @@
 // if an option is set to null it is ignored.
 $contour = env('KAFKA_CONTOUR', 'local');
 return [
-    'topics' => [
-        // 'foobars' =>  $contour . '.domain.fact.foobars.1'
+    'connections' => [
+        'default' => [
+            'settings' => [
+                'metadata.broker.list' => env('KAFKA_BROKER_LIST'),
+                'security.protocol' => env('KAFKA_SECURITY_PROTOCOL', 'plaintext'),
+                'sasl.mechanisms' => env('KAFKA_SASL_MECHANISMS'),
+                'sasl.username' => env('KAFKA_SASL_USERNAME'),
+                'sasl.password' => env('KAFKA_SASL_PASSWORD'),
+                'log_level' => env('KAFKA_DEBUG', false) ? (string)LOG_DEBUG : (string)LOG_INFO,
+                'debug' => env('KAFKA_DEBUG', false) ? 'all' : null,
+            ],
+            'topics' => [
+                // 'foobars' =>  $contour . '.domain.fact.foobars.1'
+            ]
+        ]
     ],
     'consumers' => [
         'default' => [
-            'metadata.broker.list' => env('KAFKA_BROKER_LIST'),
-            'security.protocol' => env('KAFKA_SECURITY_PROTOCOL', 'plaintext'),
-            'sasl.mechanisms' => env('KAFKA_SASL_MECHANISMS'),
-            'sasl.username' => env('KAFKA_SASL_USERNAME'),
-            'sasl.password' => env('KAFKA_SASL_PASSWORD'),
-            'log_level' => env('KAFKA_DEBUG', false) ? (string)LOG_DEBUG : (string)LOG_INFO,
-            'debug' => env('KAFKA_DEBUG', false) ? 'all' : null,
-
-            // consumer specific options
-            'group.id' => env('KAFKA_CONSUMER_GROUP_ID', env('APP_NAME')),
-            'enable.auto.commit' => true,
-            'auto.offset.reset' => 'beginning',
+            'connection' => 'default',
+            'additional-settings' => [
+                'group.id' => env('KAFKA_CONSUMER_GROUP_ID', env('APP_NAME')),
+                'enable.auto.commit' => true,
+                'auto.offset.reset' => 'beginning',
+            ],
         ],
     ],
     'producers' => [
         'default' => [
-            'metadata.broker.list' => env('KAFKA_BROKER_LIST'),
-            'security.protocol' => env('KAFKA_SECURITY_PROTOCOL', 'plaintext'),
-            'sasl.mechanisms' => env('KAFKA_SASL_MECHANISMS'),
-            'sasl.username' => env('KAFKA_SASL_USERNAME'),
-            'sasl.password' => env('KAFKA_SASL_PASSWORD'),
-            'log_level' => env('KAFKA_DEBUG', false) ? (string)LOG_DEBUG : (string)LOG_INFO,
-            'debug' => env('KAFKA_DEBUG', false) ? 'all' : null,
-
-            // producer specific options
-            'compression.codec' => env('KAFKA_PRODUCER_COMPRESSION_CODEC', 'snappy'),
+            'connection' => 'default',
+            'additional-settings' => [
+                'compression.codec' => env('KAFKA_PRODUCER_COMPRESSION_CODEC', 'snappy'),
+            ],
         ],
     ],
 ];

--- a/config/kafka.php
+++ b/config/kafka.php
@@ -2,36 +2,39 @@
 
 // configurattion options can be found here: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 // if an option is set to null it is ignored.
+$contour = env('KAFKA_CONTOUR', 'local');
 return [
-   'consumers' => [
-      'default' => [
-         'metadata.broker.list' => env('KAFKA_BROKER_LIST'),
-         'security.protocol' => env('KAFKA_SECURITY_PROTOCOL', 'plaintext'),
-         'sasl.mechanisms' => env('KAFKA_SASL_MECHANISMS'),
-         'sasl.username' => env('KAFKA_SASL_USERNAME'),
-         'sasl.password' => env('KAFKA_SASL_PASSWORD'),
-         'log_level' => env('KAFKA_DEBUG', false) ? (string) LOG_DEBUG : (string) LOG_INFO,
-         'debug' => env('KAFKA_DEBUG', false) ? 'all' : null,
+    'topics' => [
+        // 'foobars' =>  $contour . '.domain.fact.foobars.1'
+    ],
+    'consumers' => [
+        'default' => [
+            'metadata.broker.list' => env('KAFKA_BROKER_LIST'),
+            'security.protocol' => env('KAFKA_SECURITY_PROTOCOL', 'plaintext'),
+            'sasl.mechanisms' => env('KAFKA_SASL_MECHANISMS'),
+            'sasl.username' => env('KAFKA_SASL_USERNAME'),
+            'sasl.password' => env('KAFKA_SASL_PASSWORD'),
+            'log_level' => env('KAFKA_DEBUG', false) ? (string)LOG_DEBUG : (string)LOG_INFO,
+            'debug' => env('KAFKA_DEBUG', false) ? 'all' : null,
 
-         // consumer specific options
-         'group.id' => env('KAFKA_CONSUMER_GROUP_ID', env('APP_NAME')),
-         'enable.auto.commit' => true,
-         'auto.offset.reset' => 'beginning',
-         'allow.auto.create.topics' => true,
-      ],
-   ],
-   'producers' => [
-      'default' => [
-         'metadata.broker.list' => env('KAFKA_BROKER_LIST'),
-         'security.protocol' => env('KAFKA_SECURITY_PROTOCOL', 'plaintext'),
-         'sasl.mechanisms' => env('KAFKA_SASL_MECHANISMS'),
-         'sasl.username' => env('KAFKA_SASL_USERNAME'),
-         'sasl.password' => env('KAFKA_SASL_PASSWORD'),
-         'log_level' => env('KAFKA_DEBUG', false) ? (string) LOG_DEBUG : (string) LOG_INFO,
-         'debug' => env('KAFKA_DEBUG', false) ? 'all' : null,
+            // consumer specific options
+            'group.id' => env('KAFKA_CONSUMER_GROUP_ID', env('APP_NAME')),
+            'enable.auto.commit' => true,
+            'auto.offset.reset' => 'beginning',
+        ],
+    ],
+    'producers' => [
+        'default' => [
+            'metadata.broker.list' => env('KAFKA_BROKER_LIST'),
+            'security.protocol' => env('KAFKA_SECURITY_PROTOCOL', 'plaintext'),
+            'sasl.mechanisms' => env('KAFKA_SASL_MECHANISMS'),
+            'sasl.username' => env('KAFKA_SASL_USERNAME'),
+            'sasl.password' => env('KAFKA_SASL_PASSWORD'),
+            'log_level' => env('KAFKA_DEBUG', false) ? (string)LOG_DEBUG : (string)LOG_INFO,
+            'debug' => env('KAFKA_DEBUG', false) ? 'all' : null,
 
-         // producer specific options
-         'compression.codec' => env('KAFKA_PRODUCER_COMPRESSION_CODEC', 'snappy'),
-      ],
-   ],
+            // producer specific options
+            'compression.codec' => env('KAFKA_PRODUCER_COMPRESSION_CODEC', 'snappy'),
+        ],
+    ],
 ];

--- a/src/Commands/CheckTopicsExistsCommand.php
+++ b/src/Commands/CheckTopicsExistsCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Ensi\LaravelPhpRdKafka\Commands;
+
+use Ensi\LaravelPhpRdKafka\KafkaFacade;
+use Illuminate\Console\Command;
+
+class CheckTopicsExistsCommand extends Command
+{
+    protected $signature = 'kafka:find-not-created-topics
+                            {--validate : вернуть ошибку если есть не созданные топики}';
+    protected $description = 'Проверить что все топики из kafka.topics существуют';
+
+    public function handle(): int
+    {
+        $totalDesiredTopics = 0;
+        $notFoundTopics = [];
+
+        $connectionNames = KafkaFacade::availableConnections();
+
+        foreach ($connectionNames as $connectionName) {
+            $existingTopics = $this->getExistingTopics($connectionName);
+
+            $desiredTopics = KafkaFacade::allTopics($connectionName);
+            $totalDesiredTopics += count($desiredTopics);
+
+            foreach ($desiredTopics as $topicName) {
+                if (!in_array($topicName, $existingTopics)) {
+                    $notFoundTopics[] = $topicName;
+                }
+            }
+        }
+
+        $notFoundTopics = count($notFoundTopics);
+        if ($notFoundTopics) {
+            $this->output->writeln(join("\n", $notFoundTopics));
+        }
+
+        if ($this->option('validate')) {
+            if ($notFoundTopics) {
+                $this->output->writeln("\nThere are {$notFoundTopics} not created topics");
+
+                return self::FAILURE;
+            } else {
+                $this->output->writeln("All {$totalDesiredTopics} desired topics exists");
+
+                return self::SUCCESS;
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function getExistingTopics(string $connectionName): array
+    {
+        $rdKafka = KafkaFacade::rdKafka($connectionName);
+        $metadata = $rdKafka->getMetadata(true, null, 2000);
+
+        $existingTopics = [];
+        foreach ($metadata->getTopics() as $topicMeta) {
+            $existingTopics[] = $topicMeta->getTopic();
+        }
+
+        return $existingTopics;
+    }
+}

--- a/src/KafkaFacade.php
+++ b/src/KafkaFacade.php
@@ -5,9 +5,10 @@ namespace Ensi\LaravelPhpRdKafka;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static string|null topicName(string $topicKey)
- * @method static \RdKafka\Conf consumerConfig(string $name)
- * @method static \RdKafka\Conf producerConfig(string $name)
+ * @method static string[] availableConnections()
+ * @method static string[] allTopics(string $connection)
+ * @method static string topicName(string $connection, string $topicKey)
+ * @method static string topicNameByClient(string $clientType, string $clientName, string $topicKey)
  * @method static \RdKafka\KafkaConsumer consumer(string $name)
  * @method static \RdKafka\Producer producer(string $name)
  *

--- a/src/KafkaFacade.php
+++ b/src/KafkaFacade.php
@@ -5,6 +5,12 @@ namespace Ensi\LaravelPhpRdKafka;
 use Illuminate\Support\Facades\Facade;
 
 /**
+ * @method static string|null topicName(string $topicKey)
+ * @method static \RdKafka\Conf consumerConfig(string $name)
+ * @method static \RdKafka\Conf producerConfig(string $name)
+ * @method static \RdKafka\KafkaConsumer consumer(string $name)
+ * @method static \RdKafka\Producer producer(string $name)
+ *
  * @see \Ensi\LaravelPhpRdKafka\KafkaManager
  */
 class KafkaFacade extends Facade

--- a/src/KafkaFacade.php
+++ b/src/KafkaFacade.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static string topicNameByClient(string $clientType, string $clientName, string $topicKey)
  * @method static \RdKafka\KafkaConsumer consumer(string $name)
  * @method static \RdKafka\Producer producer(string $name)
+ * @method static \RdKafka\Producer rdKafka(string $connection)
  *
  * @see \Ensi\LaravelPhpRdKafka\KafkaManager
  */

--- a/src/KafkaManager.php
+++ b/src/KafkaManager.php
@@ -118,6 +118,17 @@ class KafkaManager
    }
 
 
+    public function topicName(string $topicKey): ?string
+    {
+        $topicList = $this->app['config']["kafka.topics"];
+        if (!isset($topicList[$topicKey])) {
+            throw new InvalidArgumentException("Topic with key '{$topicKey}' is not registered in kafka.topics");
+        }
+
+        return $topicList[$topicKey];
+    }
+
+
    protected function makeConfig(string $name, string $type): Conf
    {
       $availableValues = $this->app['config']["kafka.{$type}s"];

--- a/src/KafkaManager.php
+++ b/src/KafkaManager.php
@@ -2,166 +2,147 @@
 
 namespace Ensi\LaravelPhpRdKafka;
 
-use Illuminate\Support\Arr;
 use InvalidArgumentException;
-use Illuminate\Contracts\Foundation\Application;
 use RdKafka\Conf;
-use RdKafka\Producer;
 use RdKafka\KafkaConsumer;
+use RdKafka\Producer;
 
 class KafkaManager
 {
-   /**
-    * The application instance.
-    *
-    * @var \Illuminate\Contracts\Foundation\Application
-    */
-   protected $app;
+    /** @var array<KafkaConsumer> */
+    protected $consumers = [];
 
-   /**
-    * Consumers configs.
-    *
-    * @var array
-    */
-   protected $consumersConfigs = [];
+    /** @var array<Producer> */
+    protected $producers = [];
 
-   /**
-    * Producers configs.
-    *
-    * @var array
-    */
-   protected $producersConfigs = [];
+    protected $config = [];
 
-   /**
-    * Consumers.
-    *
-    * @var array
-    */
-   protected $consumers = [];
-
-   /**
-    * Producers.
-    *
-    * @var array
-    */
-   protected $producers = [];
-
-   /**
-    * Create a new kafka manager instance.
-    *
-    * @param  Application  $app
-    * @return void
-    */
-   public function __construct(Application $app)
-   {
-      $this->app = $app;
-   }
-
-   /**
-    * Get a consumer config instance.
-    *
-    * @param  string  $name
-    * @return Conf
-    */
-   public function consumerConfig(string $name = 'default'): Conf
-   {
-      if (!isset($this->consimersConfigs[$name])) {
-         $this->consimersConfigs[$name] = $this->makeConfig($name, 'consumer');
-      }
-
-      return $this->consimersConfigs[$name];
-   }
-
-   /**
-    * Get a producer config instance.
-    *
-    * @param  string  $name
-    * @return Conf
-    */
-   public function producerConfig(string $name = 'default'): Conf
-   {
-      if (!isset($this->producersConfigs[$name])) {
-         $this->producersConfigs[$name] = $this->makeConfig($name, 'producer');
-      }
-
-      return $this->producersConfigs[$name];
-   }
-
-   /**
-    * Get a consumer instance.
-    *
-    * @param  string  $name
-    * @return KafkaConsumer
-    */
-   public function consumer(string $name = 'default'): KafkaConsumer
-   {
-      if (!isset($this->consumers[$name])) {
-         $this->consumers[$name] = new KafkaConsumer($this->consumerConfig($name));
-      }
-
-      return $this->consumers[$name];
-   }
-
-   /**
-    * Get a producer instance.
-    *
-    * @param  string  $name
-    * @return Producer
-    */
-   public function producer(string $name = 'default'): Producer
-   {
-      if (!isset($this->producers[$name])) {
-         $this->producers[$name] = new Producer($this->producerConfig($name));
-      }
-
-      return $this->producers[$name];
-   }
-
-
-    public function topicName(string $topicKey): ?string
+    public function __construct()
     {
-        $topicList = $this->app['config']["kafka.topics"];
-        if (!isset($topicList[$topicKey])) {
+        $this->config = config('kafka');
+    }
+
+    /**
+     * Get a consumer instance.
+     *
+     * @param string $name
+     * @return KafkaConsumer
+     */
+    public function consumer(string $name = 'default'): KafkaConsumer
+    {
+        if (!isset($this->consumers[$name])) {
+            $this->consumers[$name] = new KafkaConsumer($this->makeKafkaConf($name, 'consumer'));
+        }
+
+        return $this->consumers[$name];
+    }
+
+    /**
+     * Get a producer instance.
+     *
+     * @param string $name
+     * @return Producer
+     */
+    public function producer(string $name = 'default'): Producer
+    {
+        if (!isset($this->producers[$name])) {
+            $this->producers[$name] = new Producer($this->makeKafkaConf($name, 'producer'));
+        }
+
+        return $this->producers[$name];
+    }
+
+    public function availableConnections(): array
+    {
+        return array_keys($this->config['connections']);
+    }
+
+    public function allTopics(string $connection): array
+    {
+        $connectionConfig = $this->rawConnectionConfig($connection);
+
+        return $connectionConfig['topics'];
+    }
+
+    public function topicName(string $connection, string $topicKey): string
+    {
+        $connectionConfig = $this->rawConnectionConfig($connection);
+
+        if (!isset($connectionConfig['topics'][$topicKey])) {
             throw new InvalidArgumentException("Topic with key '{$topicKey}' is not registered in kafka.topics");
         }
 
-        return $topicList[$topicKey];
+        return $connectionConfig['topics'][$topicKey];
     }
 
+    public function topicNameByClient(string $clientType, string $clientName, string $topicKey): string
+    {
+        $clientConfig = $this->rawClientConfig($clientType, $clientName);
 
-   protected function makeConfig(string $name, string $type): Conf
-   {
-      $availableValues = $this->app['config']["kafka.{$type}s"];
+        return $this->topicName($clientConfig['connection'], $topicKey);
+    }
 
-      if (is_null($configValues = Arr::get($availableValues, $name))) {
-         throw new InvalidArgumentException("$type config [kafka.{$type}s.{$name}] not found.");
-      }
+    protected function makeKafkaConf(string $clientName, string $clientType): Conf
+    {
+        $rawConnectionSettings = $this->rawKafkaSettings($clientName, $clientType);
+        $cleanedSettings = $this->cleanupKafkaSettings($rawConnectionSettings);
 
-      $config = new Conf();
-      foreach ($this->cleanupConfigValues($configValues) as $key => $value) {
-         $config->set($key, $value);
-      }
+        $config = new Conf();
+        foreach ($cleanedSettings as $key => $value) {
+            $config->set($key, $value);
+        }
 
-      return $config;
-   }
+        return $config;
+    }
 
-   protected function cleanupConfigValues(array $configValues)
-   {
-      foreach ($configValues as $key => $value) {
-         if ($value === null) {
-            unset($configValues[$key]);
-         }
-      }
+    /**
+     * Get raw kafka settings array, from merging of client additional-settings and connection settings
+     * @param string $clientName client name (key in kafka.consumers or kafka.producer)
+     * @param string $clientType 'consumer' or 'producer'
+     * @return array<string,mixed>
+     */
+    protected function rawKafkaSettings(string $clientName, string $clientType): array
+    {
+        $clientConfig = $this->rawClientConfig($clientType, $clientName);
+        $connectionConfig = $this->rawConnectionConfig($clientConfig['connection']);
 
-      $booleanToStrings = [
-         'enable.auto.commit',
-      ];
-      foreach ($booleanToStrings as $key) {
-         if (isset($configValues[$key])) {
-            $configValues[$key] = Helpers::stringifyBoolean($configValues[$key]);
-         }
-      }
+        return array_merge($connectionConfig['settings'], $clientConfig['additional-settings']);
+    }
 
-      return $configValues;
-   }
+    protected function rawConnectionConfig(string $connectionName): array
+    {
+        if (!isset($this->config['connections'][$connectionName])) {
+            throw new InvalidArgumentException("connection config [kafka.connections.{$connectionName}] not found.");
+        }
+
+        return $this->config['connections'][$connectionName];
+    }
+
+    protected function rawClientConfig(string $clientType, string $clientName): array
+    {
+        $haystack = $clientType . 's';
+        if (!isset($this->config[$haystack][$clientName])) {
+            throw new InvalidArgumentException("$clientType config [kafka.{$clientType}s.{$clientName}] not found.");
+        }
+
+        return $this->config[$haystack][$clientName];
+    }
+
+    /**
+     * Remove nulls and turn booleans to strings
+     * @param array<string,mixed> $configValues
+     * @return array<string,mixed>
+     */
+    protected function cleanupKafkaSettings(array $configValues): array
+    {
+        array_walk($configValues, function ($value, $key) use (&$result) {
+            if (is_null($value)) {
+                return;
+            }
+
+            $result[$key] = Helpers::stringifyBoolean($value);
+        });
+
+        return $result;
+    }
 }

--- a/src/LaravelPhpRdKafkaServiceProvider.php
+++ b/src/LaravelPhpRdKafkaServiceProvider.php
@@ -2,6 +2,10 @@
 
 namespace Ensi\LaravelPhpRdKafka;
 
+use Ensi\LaravelPhpRdKafka\Commands\CheckTopicsExistsCommand;
+use Ensi\LaravelPhpRdKafkaConsumer\Commands\KafkaCheckOffsetsCommand;
+use Ensi\LaravelPhpRdKafkaConsumer\Commands\KafkaConsumeCommand;
+use Ensi\LaravelPhpRdKafkaConsumer\Commands\KafkaSetOffset;
 use Illuminate\Support\ServiceProvider;
 
 class LaravelPhpRdKafkaServiceProvider extends ServiceProvider
@@ -26,6 +30,10 @@ class LaravelPhpRdKafkaServiceProvider extends ServiceProvider
             $this->publishes([
                 $this->packageBasePath("/../config/kafka.php") => config_path("kafka.php"),
             ], "kafka-config");
+
+            $this->commands([
+                CheckTopicsExistsCommand::class,
+            ]);
         }
     }
 


### PR DESCRIPTION
Цель - добавить консольную команду, с помощью которой можно будет понять созданы ли в кафке все нужные для работы топики и какие именно не созданы, чтобы использовать её (команду) в ci/cd пайплайне для предотвращения отгрузки приложения без топиков.

Для того чтобы рационально хранить список топиков в коде приложения, пришлось изменить структуру config/kafka.php,
так что обратной совместимости нет.